### PR TITLE
Feature: cachup subscriptions/projections

### DIFF
--- a/eventually-core/src/subscription.rs
+++ b/eventually-core/src/subscription.rs
@@ -82,12 +82,12 @@ pub type SubscriptionStream<'a, S> = BoxStream<
 /// A Subscription to an [`EventStream`] which can be "checkpointed":
 /// keeps a record of the latest message processed by itself using [`checkpoint`],
 /// and can resume working from such message - either with the infinite [`resume`],
-/// or finite [`cachup`].
+/// or finite [`catch_up`].
 ///
 /// [`EventStream`]: type.EventStream.html
 /// [`resume`]: trait.Subscription.html#method.resume
 /// [`checkpoint`]: trait.Subscription.html#method.checkpoint
-/// [`cachup`]: trait.Subscription.html#method.cachup
+/// [`catchup`]: trait.Subscription.html#method.catch_up
 pub trait Subscription {
     /// Type of the Source id, typically an [`AggregateId`].
     ///
@@ -113,12 +113,12 @@ pub trait Subscription {
     /// version processed.
     fn checkpoint(&self, version: u32) -> BoxFuture<Result<(), Self::Error>>;
 
-    /// Caches-up to  the current state of a `Subscription` by returning the [`EventStream`],
+    /// Catches-up to  the current state of a `Subscription` by returning the [`EventStream`],
     /// starting from the last event processed by the `Subscription`. The stream stops
     /// (is exhausted) once there are no more events to process.
     ///
     /// [`EventStream`]: type.EventStream.html
-    fn cachup(&self) -> BoxFuture<Result<SubscriptionStream<Self>, Self::Error>>;
+    fn catch_up(&self) -> BoxFuture<Result<SubscriptionStream<Self>, Self::Error>>;
 }
 
 /// Error type returned by a [`Transient`] Subscription.
@@ -261,7 +261,7 @@ where
     type Event = Store::Event;
     type Error = Error;
 
-    fn cachup(&self) -> BoxFuture<Result<SubscriptionStream<Self>, Self::Error>> {
+    fn catch_up(&self) -> BoxFuture<Result<SubscriptionStream<Self>, Self::Error>> {
         Box::pin(async move {
             let one_off_stream = self.stream_stored().await?;
 

--- a/eventually-postgres/src/subscription.rs
+++ b/eventually-postgres/src/subscription.rs
@@ -288,7 +288,7 @@ where
         })
     }
 
-    fn cachup(&self) -> BoxFuture<Result<SubscriptionStream<Self>, Self::Error>> {
+    fn catch_up(&self) -> BoxFuture<Result<SubscriptionStream<Self>, Self::Error>> {
         // TODO: refactor bits
         let fut = async move {
             let last_sequence_number = self.last_sequence_number.load(Ordering::Relaxed);

--- a/eventually-redis/src/subscription.rs
+++ b/eventually-redis/src/subscription.rs
@@ -123,7 +123,7 @@ where
         Box::pin(fut)
     }
 
-    fn cachup(&self) -> BoxFuture<SubscriptionResult<SubscriptionStream<Self>>> {
+    fn catch_up(&self) -> BoxFuture<SubscriptionResult<SubscriptionStream<Self>>> {
         let fut = async move {
             let keys_stream = stream::into_xread_catchup_stream(
                 self.conn.clone(),

--- a/eventually-util/src/inmemory/projector.rs
+++ b/eventually-util/src/inmemory/projector.rs
@@ -80,7 +80,7 @@ where
         #[cfg(feature = "with-tracing")]
         let projection_type = std::any::type_name::<P>();
         let mut stream = match stream_type {
-            StreamType::Cachup => self.subscription.cachup(),
+            StreamType::Cachup => self.subscription.catch_up(),
             StreamType::Resume => self.subscription.resume(),
         }
         .await?;


### PR DESCRIPTION
Hi there :smiley: 

# Quick overview

A new feature proposal for subscriptions and/or projections - ability to catch up to the current state without the long-running persistent subscription.

# Motivation
There are a couple of problems with the currently available subscriptions (and therefore projections):
 - `EventSubscribers` create the background process that might fail, as discussed in  https://github.com/eventually-rs/eventually-rs/discussions/147 and not addressed here.
 - Each projection, when used with a database, consumes a single permanent connection to the said database, and the reason for this PR.
 
Essentially, the current implementation makes the effort to have the events arrive at the receiving end of the subscription as soon as possible, therefore keeping the projections as up-to-date as we can. This, however, bears the cost of captured database connections, as mentioned above. It might not be as relevant for in-memory projections (and maybe also redis, not sure?), but for postgresql this is a rather expensive price to pay, especially if multiple projections are present.

The alternative is to expose a method that catches up with the current state of the `EventStore`, but does not keep the connection open. Then the synchronization is left up to the user to update as often as is required.

# Other

I also took the liberty of extracting a couple of methods for structs that implement `Subscription` - however as this is a purely stylistic thing (which I'm not 100% convinced I'm happy with myself right now), let me know if you'd rather the new function bodies are in-lined.

# TODO:
 - [ ] Tests for inmemory catchup subscription / projection
 - [ ]  Tests for `postgresql` catchup subscription / projection
 - [ ] Tests for `redis` catchup subscription / projection
 - [ ] Add an example to the app?